### PR TITLE
Adding no search results message

### DIFF
--- a/src/main/resources/templates/search-results.html
+++ b/src/main/resources/templates/search-results.html
@@ -58,6 +58,11 @@
                     <h2> Search Results </h2>
                 </div>
             </div>
+            <div th:if="${#lists.isEmpty(results)}" class="row gx-4 justify-content-center">
+                <div class="col-lg-12">
+                    <h3> No results found. </h3>
+                </div>
+            </div>
         </div>
         <div class="container mt-2">
             <div class="row">


### PR DESCRIPTION
This takes care of adding a message stating 'No results found' if there are no petitions found for a given search query