### PR TITLE
Updating README to reflect change to create post mapping

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ The web app contains a number of paths which allow users to:
 
 ## Post Mappings
 ```
-/create
+/create/new
 ```
 - This takes user input for petition name, description, and scope and creates the petition.
 ```


### PR DESCRIPTION
This switches the README's reference of the /create post mapping to /create/new